### PR TITLE
Fix broken CI test, apply new lint rules

### DIFF
--- a/geofrontcli/client.py
+++ b/geofrontcli/client.py
@@ -19,7 +19,7 @@ from six.moves.urllib.request import OpenerDirector, Request, build_opener
 
 from .key import PublicKey
 from .ssl import create_urllib_https_handler
-from .version import MIN_PROTOCOL_VERSION, MAX_PROTOCOL_VERSION, VERSION
+from .version import MAX_PROTOCOL_VERSION, MIN_PROTOCOL_VERSION, VERSION
 
 __all__ = ('REMOTE_PATTERN', 'BufferedResponse',
            'Client', 'ExpiredTokenIdError',
@@ -197,7 +197,7 @@ class Client(object):
                         extra={'user_waiting': False})
             return dict((alias, fmt(remote))
                         for alias, remote in result.items())
-        except:
+        except Exception:
             logger.info('Failed to fetch the list of remotes.',
                         extra={'user_waiting': False})
             raise
@@ -227,7 +227,7 @@ class Client(object):
             logger.info('Authentication is required.',
                         extra={'user_waiting': False})
             raise
-        except:
+        except Exception:
             logger.info('Authorization to %s has failed.', alias,
                         extra={'user_waiting': False})
             raise

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,11 @@ minversion = 1.6.0
 
 [testenv]
 deps =
-    flake8 >= 3.3.0
-    flake8-import-order-spoqa
-    pytest >= 3.0.7, < 3.1.0
-    pytest-flake8 >= 0.8.1, < 0.9.0
-    testtools
+    flake8 >= 3.5.0, < 3.8.0
+    flake8-import-order-spoqa >= 1.5.0, < 2.0.0
+    pytest >= 3.5.0, < 4.0.0
+    pytest-flake8 >= 1.0.4, < 1.1.0
+    testtools >= 2.3.0, < 3.0.0
 # testtools is required by dirspec
 commands =
     flake8 geofrontcli

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ deps =
     testtools >= 2.3.0, < 3.0.0
 # testtools is required by dirspec
 commands =
-    flake8 geofrontcli
     py.test {posargs:--durations=5}
 
 [pytest]


### PR DESCRIPTION
- Added maximum required versions to all test dependencies.
- Removed redundant `flake8` execution. It will be run by `pytest-flake8` plugin.