### PR TITLE
Add support for jump hosts. Resolves #17.

### DIFF
--- a/geofrontcli/cli.py
+++ b/geofrontcli/cli.py
@@ -329,6 +329,8 @@ def ssh(args, alias=None):
         options = get_ssh_options(remote)
     except ValueError as e:
         ssh.error(str(e))
+    if args.jump_host:
+        options.extend(['-o', 'ProxyJump==%s' % (args.jump_host)])
     subprocess.call([args.ssh] + options)
 
 
@@ -358,6 +360,8 @@ def scp(args):
         options.extend(['-S', args.ssh])
     if args.recursive:
         options.append('-r')
+    if args.jump_host:
+        options.extend(['-o', 'ProxyJump==%s' % (args.jump_host)])
     remote = src_remote or dst_remote
     remote_match = REMOTE_PATTERN.match(remote)
     if not remote_match:
@@ -414,6 +418,14 @@ for p in authenticate, authorize, start, ssh, scp, go:
         action='store_false',
         help='do not open the authentication web page using browser.  '
              'instead print the url to open'
+    )
+
+
+for p in ssh, scp:
+    p.add_argument(
+        '-J', '--jump-host',
+        default=None,
+        help='Proxy jump host to use'
     )
 
 

--- a/geofrontcli/cli.py
+++ b/geofrontcli/cli.py
@@ -330,7 +330,7 @@ def ssh(args, alias=None):
     except ValueError as e:
         ssh.error(str(e))
     if args.jump_host:
-        options.extend(['-o', 'ProxyJump==%s' % (args.jump_host)])
+        options.extend(['-o', 'ProxyJump=={}'.format(args.jump_host)])
     subprocess.call([args.ssh] + options)
 
 
@@ -361,7 +361,7 @@ def scp(args):
     if args.recursive:
         options.append('-r')
     if args.jump_host:
-        options.extend(['-o', 'ProxyJump==%s' % (args.jump_host)])
+        options.extend(['-o', 'ProxyJump=={}'.format(args.jump_host)])
     remote = src_remote or dst_remote
     remote_match = REMOTE_PATTERN.match(remote)
     if not remote_match:


### PR DESCRIPTION
It is worth noting that one drawback of this feature is that it will only work on OpenSSH version 7.3 and above. Given that 7.3 has been released in August 2016, I don't consider this a huge problem.

Could you please review and let me know if this is a feature that can be introduced in mainline?