### PR TITLE
Fix regression introduced by feature for #17

### DIFF
--- a/geofrontcli/cli.py
+++ b/geofrontcli/cli.py
@@ -419,9 +419,6 @@ for p in authenticate, authorize, start, ssh, scp, go:
         help='do not open the authentication web page using browser.  '
              'instead print the url to open'
     )
-
-
-for p in ssh, scp:
     p.add_argument(
         '-J', '--jump-host',
         default=None,


### PR DESCRIPTION
#17 구현시 args에 jump_host를 넣는 스코프를 최소화하기 위해서 별도 루프를 돌렸으나, 적어도 한군데에서 경유 호출이 (go -> ssh) 일어나는것이 확인되어 쓸모는 없더라도 일단은 추가를 다 하는 형태로 바꿨습니다.

이 패치가 없으면 경유해서 ssh/scp 로 가는 명령어 수행시 (e.g. go) 에러가 납니다.