### PR TITLE
Add option to allow command execution.

### DIFF
--- a/geofrontcli/cli.py
+++ b/geofrontcli/cli.py
@@ -331,7 +331,11 @@ def ssh(args, alias=None):
         ssh.error(str(e))
     if args.jump_host:
         options.extend(['-o', 'ProxyJump=={}'.format(args.jump_host)])
-    subprocess.call([args.ssh] + options)
+
+    if args.exec:
+        subprocess.call([args.ssh] + options + [args.exec])
+    else:
+        subprocess.call([args.ssh] + options)
 
 
 ssh.add_argument('remote', help='the remote alias to ssh')
@@ -418,6 +422,11 @@ for p in authenticate, authorize, start, ssh, scp, go:
         action='store_false',
         help='do not open the authentication web page using browser.  '
              'instead print the url to open'
+    )
+    p.add_argument(
+        '-X', '--exec',
+        default=None,
+        help='Command to run'
     )
     p.add_argument(
         '-J', '--jump-host',


### PR DESCRIPTION
원격 호스트에 명령을 실행할 수 있는 기능입니다. (geofront-cli ssh 에서만 동작합니다.)