### PR TITLE
Update import path for MutableMapping to collections.abc

### DIFF
--- a/geofrontcli/client.py
+++ b/geofrontcli/client.py
@@ -2,7 +2,6 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 """
-import collections
 import contextlib
 import io
 import json
@@ -11,6 +10,7 @@ import re
 import sys
 import uuid
 
+from collections.abc import MutableMapping
 from keyring import get_password, set_password
 from six import string_types
 from six.moves.urllib.error import HTTPError
@@ -255,7 +255,7 @@ class BufferedResponse(io.BytesIO):
         self.headers = headers
 
 
-class PublicKeyDict(collections.MutableMapping):
+class PublicKeyDict(MutableMapping):
     """:class:`dict`-like object that contains public keys."""
 
     def __init__(self, client):


### PR DESCRIPTION
collections.MutableMapping이 Python 3.3 이후 collections.abc 모듈로 이동되어 AttributeError: module 'collections' has no attribute 'MutableMapping' 에러가 발생합니다.

python release status https://devguide.python.org/versions/ 기준으로 python 3.3 버전 지원이 종료되어, 위와 같은 방식으로 변경하는 것을 검토 부탁드리겠습니다.